### PR TITLE
fix: some adapter can't get friend and group list

### DIFF
--- a/lib/components/Account.js
+++ b/lib/components/Account.js
@@ -1,10 +1,18 @@
 export async function getAccountInfo(bot) {
-  const friends = await bot.GetFriendList()
-  const groups = await bot.GetGroupList()
-    const friendNumber = friends.length
-    const groupNumber = groups.length
-    return {
-        key: 'Account',
-        value: `${friendNumber} Friends & ${groupNumber} Groups`
-    }
+  let friendNumber = NaN, groupNumber = NaN
+  try {
+    friendNumber = (await bot.GetFriendList()).length
+  } catch (error) {
+    /** 推测适配器未适配GetFriendList方法 */
+  }
+  try {
+    groupNumber = (await bot.GetGroupList()).length
+  } catch (error) {
+    /** 推测适配器未适配GetGroupList方法 */
+  }
+  return {
+    key: 'Account',
+    value: `${friendNumber} Friends & ${groupNumber} Groups`
+  }
 }
+


### PR DESCRIPTION
some adapter may throw an error when trying to access function  GetFriendList() and GetGroupList(),  such as QQBot.